### PR TITLE
Add explicit GRANTs for watchlist table (Supabase schema policy change)

### DIFF
--- a/supabase/migrations/20260527000000_grant_watchlist_access.sql
+++ b/supabase/migrations/20260527000000_grant_watchlist_access.sql
@@ -1,0 +1,4 @@
+-- Explicit grants required for Supabase Data API access after Oct 30, 2026
+-- See: https://supabase.com/changelog (schema exposure policy change)
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.watchlist TO anon;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.watchlist TO authenticated;


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Adds a new migration `20260527000000_grant_watchlist_access.sql` with explicit `GRANT` statements for the `watchlist` table
- Grants `SELECT, INSERT, UPDATE, DELETE` to both `anon` and `authenticated` roles
- Required to maintain Data API access (PostgREST / supabase-js) after Supabase's policy change

## Context

Supabase announced that starting **October 30, 2026**, new tables in the `public` schema will no longer be exposed to the Data API by default on existing projects. Without an explicit `GRANT`, the app would lose access to the `watchlist` table.

## Test plan

- [ ] Apply migration via `npm run supabase:db:push`
- [ ] Confirm app still reads/writes to `watchlist` normally
- [ ] Optionally run `supabase db diff` to verify no unintended changes

https://claude.ai/code/session_01NnV13Su5bdQzJVnm6MUaMj
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01NnV13Su5bdQzJVnm6MUaMj)_